### PR TITLE
Add container subnet gateway and more

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,1 +1,6 @@
 terraform.tfvars
+.terraform.tfstate.lock.info
+.terraform/
+openstack_user_config.yml
+terraform.tfstate
+terraform.tfstate.backup

--- a/terraform/BareMetal.tf
+++ b/terraform/BareMetal.tf
@@ -35,7 +35,7 @@ resource "packet_device" "compute" {
   }
 }
 
-resource "packet_device" "infra" {
+resource "packet_device" "control" {
 
   count            = "${var.infra_count}"
   hostname         = "${format("infra%01d", count.index)}"
@@ -65,6 +65,12 @@ resource "packet_device" "infra" {
   provisioner "file" {
     source      = "deployment_host.sh"
     destination = "deployment_host.sh"
+  }
+
+# NOTE(curtis): This file is copied into place by deployment_host.sh
+  provisioner "file" {
+    source      = "user_variables.yml"
+    destination = "user_variables.yml"
   }
 
   # private SSH key for OSA to use

--- a/terraform/ContainerSubnet.tf
+++ b/terraform/ContainerSubnet.tf
@@ -8,6 +8,14 @@ data "packet_precreated_ip_block" "private_block" {
     project_id       = "${var.packet_project_id}"
     address_family   = 4
     public           = false
+
+}
+
+
+locals {
+    # NOTE(curtis): Use the first IP in the range as the gateway, put this on br-mgmt
+    control_0_container_subnet_gw = "${cidrhost(packet_ip_attachment.control_ip_block_0.cidr_notation,1)}"
+    compute_0_container_subnet_gw = "${cidrhost(packet_ip_attachment.compute_ip_block_0.cidr_notation,1)}"
 }
 
 # assigned a /25 by default so we'll add one bit and get a /26

--- a/terraform/deployment_host.sh
+++ b/terraform/deployment_host.sh
@@ -3,3 +3,4 @@ apt-get install -y aptitude build-essential git ntp ntpdate python-dev sudo
 git clone -b 18.1.1 https://git.openstack.org/openstack/openstack-ansible /opt/openstack-ansible
 (cd /opt/openstack-ansible; scripts/bootstrap-ansible.sh)
 cp -R /opt/openstack-ansible/etc/openstack_deploy/ /etc/openstack_deploy
+cp $HOME/user_variables.yml /etc/openstack_deploy/

--- a/terraform/openstack_user_config-yml.tpl
+++ b/terraform/openstack_user_config-yml.tpl
@@ -12,10 +12,10 @@
 
 ---
 cidr_networks: &cidr_networks
-  container: ${project_private_subnet}
+  container: ${control_0_container_subnet}
 
 used_ips:
-  - ${all_host_private_ips}
+  - ${all_host_private_ips},${control_0_container_subnet_gw}
   - ${all_host_public_ips}
 
 global_overrides:
@@ -44,11 +44,11 @@ global_overrides:
           - hosts
         is_container_address: true
         is_ssh_address: true
+        # NOTE(curtis): Not sure this is doing anything
         static_routes:
           # Route to container networks
-          - cidr: ${project_private_subnet}
-# what goes here?
-#            gateway: 
+          - cidr: ${control_0_container_subnet}
+            gateway: ${control_0_private_gw}
     - network:
         container_bridge: "br-flat"
         container_type: "veth"

--- a/terraform/openstack_user_config.tf
+++ b/terraform/openstack_user_config.tf
@@ -33,7 +33,6 @@ JSON
     hostname  = "${element(packet_device.compute.*.hostname, count.index)}"
   }
 }
-
 data "template_file" "openstack_user_config" {
   template = "${file("${path.module}/openstack_user_config-yml.tpl")}"
 
@@ -48,6 +47,7 @@ data "template_file" "openstack_user_config" {
     compute_public_ips = "${join(",",packet_device.compute.*.access_public_ipv4)}"
 
     # NOTE(curtis): This is for setting internal and external lb in OSA user config
+    # FIXME: should follow naming standard. Also, how would this work with multiple controllers?
     first_control_public_ip = "${element(packet_device.control.*.access_public_ipv4, 0)}"
     first_control_private_ip = "${element(packet_device.control.*.access_private_ipv4, 0)}"
 
@@ -61,6 +61,7 @@ data "template_file" "openstack_user_config" {
     compute_0_private_gw     = "${lookup(packet_device.compute.0.network[2], "gateway")}"
 
     # extra block of private IPs assigned to hosts
+    control_0_container_subnet_gw = "${local.control_0_container_subnet_gw}"
     control_0_container_subnet = "${packet_ip_attachment.control_ip_block_0.cidr_notation}"
     compute_0_container_subnet = "${packet_ip_attachment.compute_ip_block_0.cidr_notation}"
 

--- a/terraform/setup-bridges.tf
+++ b/terraform/setup-bridges.tf
@@ -24,7 +24,7 @@ data "template_file" "setup-bridges-compute" {
     #add-private-ips-command = "ip addr add ${element(packet_ip_attachment.compute_ip_block.*.cidr_notation,count.index) dev br-mgmt}"
     # hard coded for a single compute node right now
     # FIXME: This will likely not work as the cidr_notation here uses the network IP, not a usable host IP, eg. minhost
-    add-private-ips-command = "ip addr add ${packet_ip_attachment.compute_ip_block_0.cidr_notation} dev br-mgmt"
+    add-private-ips-command = "ip addr add ${local.compute_0_container_subnet_gw}/27  dev br-mgmt"
   }
 }
 

--- a/terraform/setup-bridges.tf
+++ b/terraform/setup-bridges.tf
@@ -8,7 +8,8 @@ data "template_file" "setup-bridges-control" {
     # private subnet assigned to this host
     #add-private-ips-command = "ip addr add ${element(packet_ip_attachment.control_ip_block.*.cidr_notation,count.index) dev br-mgmt}"
     # hard coded for a single control node right now
-    add-private-ips-command = "ip addr add ${packet_ip_attachment.control_ip_block_0.cidr_notation} dev br-mgmt"
+    # NOTE(curtis): FIXME - need to calculate /27 somehow... 
+    add-private-ips-command = "ip addr add ${local.control_0_container_subnet_gw}/27 dev br-mgmt"
   }
 }
 
@@ -22,6 +23,7 @@ data "template_file" "setup-bridges-compute" {
     # private subnet assigned to this host
     #add-private-ips-command = "ip addr add ${element(packet_ip_attachment.compute_ip_block.*.cidr_notation,count.index) dev br-mgmt}"
     # hard coded for a single compute node right now
+    # FIXME: This will likely not work as the cidr_notation here uses the network IP, not a usable host IP, eg. minhost
     add-private-ips-command = "ip addr add ${packet_ip_attachment.compute_ip_block_0.cidr_notation} dev br-mgmt"
   }
 }

--- a/terraform/setup-bridges.tpl
+++ b/terraform/setup-bridges.tpl
@@ -6,9 +6,12 @@
 #
 
 # make this script re-entrant
-if [ `brctl show br-mgmt | grep br-mgmt | wc -l` -eq 1 ]; then
+/sbin/ip link show br-mgmt > /dev/null
+ret=$?
+echo $ret
+if [ $ret == 0 ]; then
   # if the bridge exists then leave so it doesn't get set back up again
-  exit
+  exit $ret
 fi
 
 PUBLIC_GATEWAY=`ip route list | egrep "^default" | cut -d' ' -f 3`

--- a/terraform/setup-bridges.tpl
+++ b/terraform/setup-bridges.tpl
@@ -38,7 +38,7 @@ ip addr add $PRIVATE_IP/31 dev br-mgmt
 ip link set dev br-mgmt up
 
 ip route add default via $PUBLIC_GATEWAY dev br-mgmt
-ip route add 10.0.0.8 via $PRIVATE_GATEWAY dev br-mgmt
+ip route add 10.0.0.0/8 via $PRIVATE_GATEWAY dev br-mgmt
 
 # add any elastic IPs assigned
 ${add-public-ips-command}

--- a/terraform/user_variables.yml
+++ b/terraform/user_variables.yml
@@ -1,0 +1,4 @@
+# FIXME: should reduce this space, not sure where checks are coming from in 
+# packet.com nodes. Without this mysqlchk will fail, haproxy won't forward
+# to galera, dbs can't be created.
+galera_monitoring_allowed_source: "0.0.0.0/0"

--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -56,3 +56,11 @@ variable "openstack_user_config_file" {
 variable "terraform_username" {
   description = "username running Terraform to set in host tags to help identify resource owners"
 }
+
+variable "infra_type" {
+  description = "packet.com compute plan"
+}
+
+variable "infra_count" {
+  description = "number of compute instances"
+}


### PR DESCRIPTION
We can split this commit up if needed, but what is here now is:

- compute a gateway address for the container subnet for control
- apply that gateway address to br-mgmt instead of the network IP
- configure script so that if br-mgmt exists already it isn't touched
- add a gateway IP fo the static routes, but not sure this is working
- add infra_type and infra_count as vars to vars.tf
- update .gitignore
- add a user_variables.yml file with galera mysqlchk set to 0.0.0.0/0
- Fix 10.0.0.8 issue in br setup script

This code now deploys allows the setup-*.yml commands to complete and
deploys OpenStack, but I'm sure there is more to do in terms of being
able to boot virtual machines.

**Fixes**

* fixes #9 
* fixes #6 - but renaming may have been done on purpose?
* fixes #7 - but I'm not sure where that static route actually gets injected